### PR TITLE
v1.4292

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -2,6 +2,11 @@ CHANGE_LOG
 
 For the Github commit log see here: github.com/flydog-sdr/FlyDog_SDR_GPS/commits/master
 
+v1.4292  January 24, 2021
+    Use /dev/mem instead of /dev/gpiomem, preparing for support of more development boards.
+    With --no-install-recommends option for dependencies installation during compiling.
+    Adjusted the compilation flags.
+
 v1.4291  January 23, 2021
     Followed up the upstream.
        github.com/jks-prv/Beagle_SDR_GPS

--- a/Makefile
+++ b/Makefile
@@ -260,67 +260,67 @@ ifeq ($(DEBIAN_7),true)
 	mv /tmp/sources.list /etc/apt/sources.list
 endif
 	-apt-get -y update
-	-apt-get -y install debian-archive-keyring
+	-apt-get --no-install-recommends -y install debian-archive-keyring
 	-apt-get -y update
 	@mkdir -p $(DIR_CFG)
 	touch $(KEYRING)
 
 /usr/lib/arm-linux-gnueabihf/libfftw3f.a:
-	apt-get -y install libfftw3-dev
+	apt-get --no-install-recommends -y install libfftw3-dev
 
 # NB not a typo: "clang-6.0" vs "clang-7"
 
 /usr/bin/clang-6.0:
 	# only available recently?
 	-apt-get -y update
-	apt-get -y install clang-6.0
+	apt-get --no-install-recommends -y install clang-6.0
 
 /usr/bin/clang-7:
 	-apt-get -y update
-	apt-get -y install clang-7
+	apt-get --no-install-recommends -y install clang-7
 
 /usr/bin/curl:
-	-apt-get -y install curl
+	-apt-get --no-install-recommends -y install curl
 
 /usr/bin/wget:
-	-apt-get -y install wget
+	-apt-get --no-install-recommends -y install wget
 
 /usr/sbin/avahi-autoipd:
-	#-apt-get -y install avahi-daemon avahi-utils libnss-mdns avahi-autoipd
+	#-apt-get --no-install-recommends -y install avahi-daemon avahi-utils libnss-mdns avahi-autoipd
 	-echo "Skipped"
 
 /usr/bin/upnpc:
-	#-apt-get -y install miniupnpc
+	#-apt-get --no-install-recommends -y install miniupnpc
 	-echo "Skipped"
 
 /usr/bin/dig:
-	-apt-get -y install dnsutils
+	-apt-get --no-install-recommends -y install dnsutils
 
 /usr/bin/pnmtopng:
-	-apt-get -y install pnmtopng
+	-apt-get --no-install-recommends -y install pnmtopng
 
 /sbin/ethtool:
-	#-apt-get -y install ethtool
+	#-apt-get --no-install-recommends -y install ethtool
 	-echo "Skipped"
 
 /usr/bin/sshpass:
-	-apt-get -y install sshpass
+	-apt-get --no-install-recommends -y install sshpass
 
 /usr/bin/killall:
-	-apt-get -y install psmisc
+	-apt-get --no-install-recommends -y install psmisc
 
 /usr/bin/dtc:
-	#-apt-get -y install device-tree-compiler
+	#-apt-get --no-install-recommends -y install device-tree-compiler
 	-echo "Skipped"
 
 ifeq ($(BBAI),true)
 /usr/bin/cpufreq-info:
-	-apt-get -y install cpufrequtils
+	-apt-get --no-install-recommends -y install cpufrequtils
 endif
 
 ifneq ($(DEBIAN_7),true)
 /usr/bin/jq:
-	-apt-get -y install jq
+	-apt-get --no-install-recommends -y install jq
 endif
 
 endif
@@ -1274,7 +1274,7 @@ endif
 ifeq ($(DEBIAN_DEVSYS),$(DEBIAN))
 
 /usr/bin/xz: $(KEYRING)
-	#apt-get -y install xz-utils
+	#apt-get --no-install-recommends -y install xz-utils
 	echo "Skipped"
 
 #

--- a/Makefile.comp.inc
+++ b/Makefile.comp.inc
@@ -100,7 +100,6 @@ endif
 
 # Debian target
 ifeq ($(DEBIAN_DEVSYS),$(DEBIAN))
-	#CFLAGS += -mfloat-abi=hardfp -mfpu=vfp
 	CFLAGS +=  -mfpu=vfp -mfloat-abi=hard
 	CFLAGS += -DHOST
 

--- a/Makefile.comp.inc
+++ b/Makefile.comp.inc
@@ -56,8 +56,8 @@ ifeq ($(DEBIAN_DEVSYS),$(DEVSYS))
         CC = clang
         CPP = clang++
         CPP_FLAGS += -std=gnu++11
-        CFLAGS += --target=armv7a-linux-gnueabihf
-        CFLAGS += -mfpu=neon
+        CFLAGS += --target=arm-linux-gnueabihf
+        CFLAGS += -mfpu=vfp
         CFLAGS += -mfloat-abi=hard
         CFLAGS += --sysroot=$(KIWI_XC_REMOTE_FS)
         CFLAGS += -I$(KIWI_XC_REMOTE_FS)/usr/include/c++/4.9
@@ -68,12 +68,12 @@ ifeq ($(DEBIAN_DEVSYS),$(DEVSYS))
         LDFLAGS += -fuse-ld=$(KIWI_XC_LD)
         LDFLAGS += -v
         LDFLAGS += --sysroot=$(KIWI_XC_REMOTE_FS)
-        LDFLAGS += --target=armv7a-linux-gnueabihf
+        LDFLAGS += --target=arm-linux-gnueabihf
         LDFLAGS += -L$(KIWI_XC_REMOTE_FS)/usr/lib/arm-linux-gnueabihf
         LDFLAGS += -L$(KIWI_XC_REMOTE_FS)/usr/local/lib/
 
 		ifeq ($(RPI),true)
-			CFLAGS += -mtune=cortex-a53 -mcpu=cortex-a53
+			CFLAGS += -mtune=native -mcpu=native
 		else
 			CFLAGS += -mtune=cortex-a8 -mcpu=cortex-a8
 		endif
@@ -100,8 +100,8 @@ endif
 
 # Debian target
 ifeq ($(DEBIAN_DEVSYS),$(DEBIAN))
-	#CFLAGS += -mfloat-abi=softfp -mfpu=neon
-	CFLAGS +=  -mfpu=neon -mfloat-abi=hard
+	#CFLAGS += -mfloat-abi=hardfp -mfpu=vfp
+	CFLAGS +=  -mfpu=vfp -mfloat-abi=hard
 	CFLAGS += -DHOST
 
 	BBAI = $(shell cat /dev/null)
@@ -142,7 +142,7 @@ ifeq ($(DEBIAN_DEVSYS),$(DEBIAN))
 		CC = clang-7
 		CPP = clang++-7
         VIS_OPT = -Ofast
-		CFLAGS += -mtune=cortex-a53 -mcpu=cortex-a53
+		CFLAGS += -mtune=native -mcpu=native
 		# needed for iq_display.cpp et al
 		CPP_FLAGS += -std=gnu++11
 	else

--- a/extensions/DRM/Makefile
+++ b/extensions/DRM/Makefile
@@ -33,10 +33,10 @@ else
 	        rsync -av extensions/DRM/FDK-AAC/lib/ /usr/local/lib
         
         /usr/lib/arm-linux-gnueabihf/libsndfile.so:
-	        -apt-get -y install libsndfile1-dev
+	        -apt-get --no-install-recommends -y install libsndfile1-dev
         
         /usr/lib/arm-linux-gnueabihf/libz.so:
-	        -apt-get -y install zlib1g-dev
+	        -apt-get --no-install-recommends -y install zlib1g-dev
 
     else
         LIBS += -lfdk-aac

--- a/platform/raspberrypi/peri.cpp
+++ b/platform/raspberrypi/peri.cpp
@@ -66,7 +66,7 @@ void peri_init()
 {
     int i, mem_fd;
 
-    scall("/dev/gpiomem", mem_fd = open("/dev/gpiomem", O_RDWR|O_SYNC));
+    scall("/dev/mem", mem_fd = open("/dev/mem", O_RDWR|O_SYNC));
 
     gpio = (volatile unsigned *) mmap(
         NULL,


### PR DESCRIPTION
v1.4292  January 24, 2021
Use /dev/mem instead of /dev/gpiomem, preparing for support of more development boards.
With --no-install-recommends option for dependencies installation during compiling.
Adjusted the compilation flags.