### PR TITLE
v1.4871

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -2,6 +2,9 @@ CHANGE_LOG
 
 For the Github commit log see here: github.com/flydog-sdr/FlyDog_SDR_GPS/commits/master
 
+v1.4871  January 28, 2022
+    Reverse proxy: Always use 80 port instead of 8073.
+
 v1.487  January 27, 2022
     Debian 10: Use connmanctl to change Ethernet ip address mode instead of editing the file
         /etc/network/interfaces and rebooting as is done with Debian 8 & 9.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION_MAJ = 1
-VERSION_MIN = 487
+VERSION_MIN = 4871
 
 # Caution: software update mechanism depends on format of first two lines in this file
 

--- a/net/services.cpp
+++ b/net/services.cpp
@@ -797,9 +797,9 @@ static void reg_public(void *param)
 
         bool kiwisdr_com_reg = (admcfg_bool("kiwisdr_com_register", NULL, CFG_OPTIONAL) == true);
 
-        // proxy always uses port 8073
+        // proxy always uses port 80
 	    int dom_sel = cfg_int("sdr_hu_dom_sel", NULL, CFG_REQUIRED);
-        int server_port = (dom_sel == DOM_SEL_REV)? 8073 : net.port_ext;
+        int server_port = (dom_sel == DOM_SEL_REV)? 80 : net.port_ext;
         int dom_stat = (dom_sel == DOM_SEL_REV)? net.proxy_status : (DUC_enable_start? net.DUC_status : -1);
 
 	    // done here because updating timer_sec() is sent


### PR DESCRIPTION
v1.4871  January 28, 2022
Reverse proxy: Always use 80 port instead of 8073.